### PR TITLE
feat: 게시판 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/Nadeuri/board/BoardController.java
+++ b/src/main/java/com/example/Nadeuri/board/BoardController.java
@@ -2,6 +2,8 @@ package com.example.Nadeuri.board;
 
 import com.example.Nadeuri.board.dto.request.BoardCreateRequest;
 import com.example.Nadeuri.board.dto.request.BoardPageRequestDTO;
+import com.example.Nadeuri.board.dto.request.BoardUpdateRequest;
+import com.example.Nadeuri.board.dto.response.BoardUpdateResponse;
 import com.example.Nadeuri.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,5 +60,19 @@ public class BoardController {
         log.info("pageSearchController()---");
         return ResponseEntity.ok(ApiResponse.success(boardService.pageSearch(keyword,
                 boardPageRequestDTO)));
+    }
+
+    /**
+     * 게시판 수정
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse> update(
+            @PathVariable("id") Long boardId,
+            @RequestPart("request") @Valid final BoardUpdateRequest request,
+            @RequestPart("image") final MultipartFile multipartFile
+    ) {
+        BoardEntity board = boardService.update(boardId, request, multipartFile);
+        BoardUpdateResponse response = BoardUpdateResponse.from(board);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/Nadeuri/board/BoardEntity.java
+++ b/src/main/java/com/example/Nadeuri/board/BoardEntity.java
@@ -99,4 +99,18 @@ public class BoardEntity {
                 .imageUrl(imageUrl)
                 .build();
     }
+
+    public void update(
+            final MemberEntity member,
+            final String boardTitle,
+            final String boardContent,
+            final Category category,
+            final String imageUrl
+    ) {
+        this.member = member;
+        this.boardTitle = boardTitle;
+        this.boardContent = boardContent;
+        this.category = category;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/example/Nadeuri/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/com/example/Nadeuri/board/dto/request/BoardUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.example.Nadeuri.board.dto.request;
+
+import com.example.Nadeuri.board.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class BoardUpdateRequest {
+    // TODO: 인증 도입 시 삭제 필요
+    @NotNull(message = "회원만 게시글을 작성할 수 있습니다.")
+    private Long memberId;
+
+    @NotBlank(message = "제목을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private String boardTitle;
+
+    @NotBlank(message = "내용을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private String boardContent;
+
+    @NotNull(message = "카테고리 선택은 필수입니다.")
+    private Category category;
+}

--- a/src/main/java/com/example/Nadeuri/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/example/Nadeuri/board/dto/response/BoardUpdateResponse.java
@@ -1,0 +1,32 @@
+package com.example.Nadeuri.board.dto.response;
+
+import com.example.Nadeuri.board.BoardEntity;
+import com.example.Nadeuri.board.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class BoardUpdateResponse {
+
+    @NotNull(message = "회원만 게시글을 작성할 수 있습니다.")
+    private Long memberId;
+
+    @NotBlank(message = "제목을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private String boardTitle;
+
+    @NotBlank(message = "내용을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private String boardContent;
+
+    @NotNull(message = "카테고리 선택은 필수입니다.")
+    private Category category;
+
+    public static BoardUpdateResponse from(final BoardEntity boardEntity) {
+        BoardUpdateResponse response = new BoardUpdateResponse();
+        response.memberId = boardEntity.getMember().getMemberNo();
+        response.boardTitle = boardEntity.getBoardTitle();
+        response.boardContent = boardEntity.getBoardContent();
+        response.category = boardEntity.getCategory();
+        return response;
+    }
+}


### PR DESCRIPTION
### 기능 구현
- [x] 멤버나 게시판을 찾는 메서드는 한 클래스 내에서 재사용될 가능성이 있어 private 메서드로 분리하였습니다.
- [x] 수정 로직을 유지보수성을 고려하여 엔티티 내에 추가했습니다.
- [x] 이미지를 수정할 때, 기존 이미지가 있으면 해당 이미지가 수정되고, 이미지가 없으면 엔티티에서 이미지 URL을 가져오도록 처리했습니다.
- [x] 서비스 계층에서 엔티티를 반환하고, 컨트롤러 계층에서 DTO로 변환하여 반환함으로써 서비스 메서드를 다른 모듈에서도 재사용할 수 있도록 하였습니다.

### Postman 확인
<img width="844" alt="image" src="https://github.com/user-attachments/assets/acfd2d32-98a3-4948-9cb0-1ddf9a556fc2">
