### PR TITLE
refactor: 동일 유저가 반복적으로 같은 게시판에 좋아요 및 좋아요 취소 가능하도록 수정

### DIFF
--- a/src/main/java/com/example/Nadeuri/likes/LikeEntity.java
+++ b/src/main/java/com/example/Nadeuri/likes/LikeEntity.java
@@ -15,7 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
@@ -43,12 +42,8 @@ public class LikeEntity {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Column(name = "deleted_at")
-    protected LocalDateTime deletedAt;
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
 
     @Builder
     public LikeEntity(
@@ -56,15 +51,13 @@ public class LikeEntity {
             final MemberEntity member,
             final BoardEntity board,
             final LocalDateTime createdAt,
-            final LocalDateTime updatedAt,
-            final LocalDateTime deletedAt
+            final Boolean isDeleted
     ) {
         this.id = id;
         this.member = member;
         this.board = board;
         this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.deletedAt = deletedAt;
+        this.isDeleted = isDeleted;
     }
 
     public static LikeEntity create(
@@ -74,9 +67,12 @@ public class LikeEntity {
         return LikeEntity.builder()
                 .member(member)
                 .board(board)
+                .isDeleted(false)
                 .build();
     }
-    public void recordDeletion(LocalDateTime deletedAt) {
-        this.deletedAt = deletedAt;
+
+    public void setLikeDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
+
 }


### PR DESCRIPTION
### 구현
동일 유저가 반복적으로 같은 게시판에 좋아요 및 좋아요 취소 가능하도록 수정하였습니다.

### 내용
- [x] 좋아요 등록 API
  - [x] 로그인한 유저와 게시물에 대한 좋아요 레코드가 존재하는지 확인합니다.
  - [x] 만약 존재하고 is_deleted가 true라면, 해당 레코드의 is_deleted를 false로 변경합니다.
  - [x] 만약 존재하지 않는다면, 새로운 좋아요 레코드를 생성합니다. 
  - [x] 좋아요 카운트를 1 증가합니다.
- [x] 좋아요 취소  API
  - [x] 로그인한 유저와 게시물에 대한 좋아요 레코드를 찾아 is_deleted를 true로 변경합니다.
  - [x] 좋아요 카운트를 1 감소합니다.
